### PR TITLE
incompatible latLng arrays

### DIFF
--- a/dist/leaflet.draw-src.js
+++ b/dist/leaflet.draw-src.js
@@ -803,8 +803,8 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 
 		this._tooltip.updatePosition(latlng);
 		if (this._isDrawing) {
-			this._tooltip.updateContent(this._getTooltipText());
 			this._drawShape(latlng);
+			this._tooltip.updateContent(this._getTooltipText());
 		}
 	},
 


### PR DESCRIPTION
Shown area and 'draw:created' area was not the same because of calling updateContent function before drawShape.
